### PR TITLE
📦 Add @ianvs/prettier-plugin-sort-imports and update import order

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -10,5 +10,6 @@
   "bracketSpacing": true,
   "arrowParens": "avoid",
   "endOfLine": "lf",
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss", "@ianvs/prettier-plugin-sort-imports"],
+  "importOrder": ["^react", "<THIRD_PARTY_MODULES>", "", "^@/(.*)$", "^[./]"]
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.9.1",
+    "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/git": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@eslint/js':
         specifier: 9.9.1
         version: 9.9.1
+      '@ianvs/prettier-plugin-sort-imports':
+        specifier: ^4.3.1
+        version: 4.3.1(prettier@3.3.3)
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@24.1.0(typescript@5.5.4))
@@ -191,7 +194,7 @@ importers:
         version: 3.3.3
       prettier-plugin-tailwindcss:
         specifier: 0.6.6
-        version: 0.6.6(prettier@3.3.3)
+        version: 0.6.6(@ianvs/prettier-plugin-sort-imports@4.3.1(prettier@3.3.3))(prettier@3.3.3)
       semantic-release:
         specifier: ^24.1.0
         version: 24.1.0(typescript@5.5.4)
@@ -501,6 +504,15 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@ianvs/prettier-plugin-sort-imports@4.3.1':
+    resolution: {integrity: sha512-ZHwbyjkANZOjaBm3ZosADD2OUYGFzQGxfy67HmGZU94mHqe7g1LCMA7YYKB1Cq+UTPCBqlAYapY0KXAjKEw8Sg==}
+    peerDependencies:
+      '@vue/compiler-sfc': 2.7.x || 3.x
+      prettier: 2 || 3
+    peerDependenciesMeta:
+      '@vue/compiler-sfc':
+        optional: true
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3923,6 +3935,18 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@ianvs/prettier-plugin-sort-imports@4.3.1(prettier@3.3.3)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/generator': 7.25.5
+      '@babel/parser': 7.25.4
+      '@babel/traverse': 7.25.4
+      '@babel/types': 7.25.4
+      prettier: 3.3.3
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -6472,9 +6496,11 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.6.6(prettier@3.3.3):
+  prettier-plugin-tailwindcss@0.6.6(@ianvs/prettier-plugin-sort-imports@4.3.1(prettier@3.3.3))(prettier@3.3.3):
     dependencies:
       prettier: 3.3.3
+    optionalDependencies:
+      '@ianvs/prettier-plugin-sort-imports': 4.3.1(prettier@3.3.3)
 
   prettier@3.3.3: {}
 

--- a/src/components/business/business-details-view.tsx
+++ b/src/components/business/business-details-view.tsx
@@ -1,3 +1,22 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { format } from 'date-fns'
+import {
+  Car,
+  ChevronDown,
+  Clipboard,
+  ClipboardCheck,
+  Clock,
+  ExternalLink,
+  Globe,
+  Mail,
+  Milestone,
+  Pencil,
+  Phone
+} from 'lucide-react'
+import { toast } from 'sonner'
+
 import { getBusiness } from '@/api/business'
 import ErrorComponent from '@/components/error'
 import Loading from '@/components/loading'
@@ -17,24 +36,6 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { CopyToClipboard } from '@/lib/clipboard'
 import { BASE_API_URL } from '@/lib/constants'
 import { useAuthStore } from '@/store/auth-store'
-import { useQuery } from '@tanstack/react-query'
-import { format } from 'date-fns'
-import {
-  Car,
-  ChevronDown,
-  Clipboard,
-  ClipboardCheck,
-  Clock,
-  ExternalLink,
-  Globe,
-  Mail,
-  Milestone,
-  Pencil,
-  Phone
-} from 'lucide-react'
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { toast } from 'sonner'
 
 type BusinessDetailsViewProps = {
   businessId: string | null

--- a/src/components/business/create-business-form.tsx
+++ b/src/components/business/create-business-form.tsx
@@ -1,3 +1,9 @@
+import React, { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
 import { createBusiness } from '@/api/business'
 import {
   Form,
@@ -12,11 +18,6 @@ import { useAuthStore } from '@/store/auth-store'
 import { CreateBusiness } from '@/types/business'
 import { PhotoState } from '@/types/photo'
 import { CreateBusinessSchema } from '@/validation/business'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import React, { useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { toast } from 'sonner'
 
 type CreateBusinessFormProps = {
   formId: string

--- a/src/components/business/time-range-row.tsx
+++ b/src/components/business/time-range-row.tsx
@@ -1,11 +1,12 @@
+import { useState } from 'react'
+
 import {
   Select,
-  SelectTrigger,
   SelectContent,
   SelectItem,
+  SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
-import { useState } from 'react'
 import { TableCell, TableRow } from '@/components/ui/table'
 
 type TimeRangeRowProps = {

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom'
+
 import {
   ListItem,
   NavigationMenu,
@@ -8,7 +10,6 @@ import {
   NavigationMenuTrigger,
   navigationMenuTriggerStyle
 } from '@/components/ui/navigation-menu'
-import { Link } from 'react-router-dom'
 
 export default function NavBar() {
   const businesses = [

--- a/src/components/nav/user-dropdown.tsx
+++ b/src/components/nav/user-dropdown.tsx
@@ -1,3 +1,6 @@
+import { useNavigate } from 'react-router-dom'
+import { User2 } from 'lucide-react'
+
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -10,8 +13,6 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useAuthStore } from '@/store/auth-store'
 import { User } from '@/types/user'
-import { User2 } from 'lucide-react'
-import { useNavigate } from 'react-router-dom'
 
 type UserDropdownProps = {
   user: User

--- a/src/components/product/product-list-preview.tsx
+++ b/src/components/product/product-list-preview.tsx
@@ -1,3 +1,6 @@
+import { useNavigate } from 'react-router-dom'
+import { Plus } from 'lucide-react'
+
 import {
   Carousel,
   CarouselContent,
@@ -5,8 +8,6 @@ import {
   CarouselNext,
   CarouselPrevious
 } from '@/components/ui/carousel'
-import { Plus } from 'lucide-react'
-import { useNavigate } from 'react-router-dom'
 import { Card, CardContent } from '../ui/card'
 
 type ProductListPreviewProps = {

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 
-import { cn } from '@/lib/utils'
 import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 const AlertDialog = AlertDialogPrimitive.Root
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
+import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
-import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
-import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons'
 import { DayPicker } from 'react-day-picker'
+import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons'
 
-import { cn } from '@/lib/utils'
 import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>
 

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 import { ArrowLeftIcon, ArrowRightIcon } from '@radix-ui/react-icons'
 import useEmblaCarousel, { type UseEmblaCarouselType } from 'embla-carousel-react'
 
-import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 type CarouselApi = UseEmblaCarouselType[1]
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react'
-import * as LabelPrimitive from '@radix-ui/react-label'
-import { Slot } from '@radix-ui/react-slot'
 import {
   Controller,
   ControllerProps,
@@ -9,9 +7,11 @@ import {
   FormProvider,
   useFormContext
 } from 'react-hook-form'
+import * as LabelPrimitive from '@radix-ui/react-label'
+import { Slot } from '@radix-ui/react-slot'
 
-import { cn } from '@/lib/utils'
 import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
 
 const Form = FormProvider
 

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { ChevronDownIcon } from 'lucide-react'
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { cva } from 'class-variance-authority'
+import { ChevronDownIcon } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,15 +1,7 @@
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Skeleton({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn("animate-pulse rounded-md bg-primary/10", className)}
-      {...props}
-    />
-  )
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('animate-pulse rounded-md bg-primary/10', className)} {...props} />
 }
 
 export { Skeleton }

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -1,3 +1,8 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { Loader2, Moon, Sun } from 'lucide-react'
+
 import { getCurrentUser } from '@/api/user'
 import { Button } from '@/components/ui/button'
 import {
@@ -9,10 +14,6 @@ import {
 import { getUserIdFromToken } from '@/lib/jwt'
 import { useTheme } from '@/provider/theme-provider'
 import { useAuthStore } from '@/store/auth-store'
-import { useQuery } from '@tanstack/react-query'
-import { Loader2, Moon, Sun } from 'lucide-react'
-import { useEffect } from 'react'
-import { Link } from 'react-router-dom'
 import UserDropdown from './nav/user-dropdown'
 
 export default function UserMenu() {

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 export function useMediaQuery(query: string) {
   const [value, setValue] = useState(false)

--- a/src/layout/main-layout.tsx
+++ b/src/layout/main-layout.tsx
@@ -1,7 +1,8 @@
+import { Outlet } from 'react-router-dom'
+
 import BrandIcon from '@/components/brand-icon'
 import NavBar from '@/components/nav-bar'
 import UserMenu from '@/components/user-menu'
-import { Outlet } from 'react-router-dom'
 
 export default function MainLayout() {
   return (

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,6 +1,7 @@
-import { BASE_API_URL } from '@/lib/constants'
 import axios from 'axios'
 import { z } from 'zod'
+
+import { BASE_API_URL } from '@/lib/constants'
 
 const api = axios.create({
   baseURL: BASE_API_URL

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { type ClassValue, clsx } from 'clsx'
+import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
 export function cn(...inputs: ClassValue[]) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { Toaster } from 'sonner'
 
 import '@/index.css'
+
 import { Providers } from '@/provider'
 import AppRoutes from '@/routes/app-routes'
 

--- a/src/pages/auth/login-page.tsx
+++ b/src/pages/auth/login-page.tsx
@@ -1,3 +1,10 @@
+import { useForm } from 'react-hook-form'
+import { Link, useNavigate } from 'react-router-dom'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { toast } from 'sonner'
+import { z } from 'zod'
+
+import { login } from '@/api/user'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -10,12 +17,6 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { useAuthStore } from '@/store/auth-store'
-import { login } from '@/api/user'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useForm } from 'react-hook-form'
-import { Link, useNavigate } from 'react-router-dom'
-import { toast } from 'sonner'
-import { z } from 'zod'
 
 const loginSchema = z.object({
   email: z.string().email(),

--- a/src/pages/business/current-business-page.tsx
+++ b/src/pages/business/current-business-page.tsx
@@ -1,4 +1,10 @@
-import { getCurrentUserBusiness, deleteBusiness } from '@/api/business'
+import React, { useState } from 'react'
+import { Navigate, useParams } from 'react-router-dom'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { deleteBusiness, getCurrentUserBusiness } from '@/api/business'
 import BusinessDetailsView from '@/components/business/business-details-view'
 import CreateBusinessForm from '@/components/business/create-business-form'
 import {
@@ -19,11 +25,6 @@ import { SheetDrawer } from '@/components/ui/sheet-drawer'
 import ErrorPage from '@/pages/error-page'
 import LoadingPage from '@/pages/loading-page'
 import { Business } from '@/types/business'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Plus, Trash2 } from 'lucide-react'
-import React, { useState } from 'react'
-import { Navigate, useParams } from 'react-router-dom'
-import { toast } from 'sonner'
 
 export default function CurrentUserBusinessPage() {
   const { userId } = useParams()

--- a/src/pages/business/update-business-page.tsx
+++ b/src/pages/business/update-business-page.tsx
@@ -1,3 +1,11 @@
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { Navigate, useParams } from 'react-router-dom'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useQuery } from '@tanstack/react-query'
+import { CaseSensitive, Clock, Globe, Mail, Milestone, Phone } from 'lucide-react'
+import { toast } from 'sonner'
+
 import { getBusiness } from '@/api/business'
 import TimeRangeRow from '@/components/business/time-range-row'
 import { Button } from '@/components/ui/button'
@@ -18,13 +26,7 @@ import ErrorPage from '@/pages/error-page'
 import LoadingPage from '@/pages/loading-page'
 import { UpdateBusiness } from '@/types/business'
 import { UpdateBusinessSchema } from '@/validation/business'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useQuery } from '@tanstack/react-query'
-import { CaseSensitive, Clock, Globe, Mail, Milestone, Phone } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { Navigate, useParams } from 'react-router-dom'
-import { toast } from 'sonner'
+
 export default function UpdateBusinessPage() {
   const { businessId } = useParams()
   // const queryClient = useQueryClient()

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -1,4 +1,5 @@
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
+import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet'
+
 import 'leaflet/dist/leaflet.css'
 
 export default function HomePage() {

--- a/src/pages/loading-page.tsx
+++ b/src/pages/loading-page.tsx
@@ -1,5 +1,6 @@
-import { Skeleton } from '@/components/ui/skeleton'
 import { Loader2 } from 'lucide-react'
+
+import { Skeleton } from '@/components/ui/skeleton'
 
 type LoadingPageProps = {
   message?: string

--- a/src/pages/not-found-page.tsx
+++ b/src/pages/not-found-page.tsx
@@ -1,5 +1,6 @@
-import { Button } from '@/components/ui/button'
 import { Link } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
 
 export default function NotFoundPage() {
   return (

--- a/src/pages/profile-page.tsx
+++ b/src/pages/profile-page.tsx
@@ -1,8 +1,9 @@
-import { getCurrentUser } from '@/api/user'
-import Loading from '@/pages/loading-page'
-import { useQuery } from '@tanstack/react-query'
 import { Navigate, useParams } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+
+import { getCurrentUser } from '@/api/user'
 import Error from '@/pages/error-page'
+import Loading from '@/pages/loading-page'
 
 export default function ProfilePage() {
   const { id } = useParams()

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -1,5 +1,6 @@
-import { ThemeProvider } from './provider/theme-provider'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { ThemeProvider } from './provider/theme-provider'
 
 const queryClient = new QueryClient()
 

--- a/src/routes/app-routes.tsx
+++ b/src/routes/app-routes.tsx
@@ -1,8 +1,9 @@
+import { lazy, Suspense } from 'react'
+import { Route, BrowserRouter as Router, Routes } from 'react-router-dom'
+
 import MainLayout from '@/layout/main-layout'
 import LoadingPage from '@/pages/loading-page'
 import PrivateRoutes from '@/routes/private-route'
-import { lazy, Suspense } from 'react'
-import { Route, BrowserRouter as Router, Routes } from 'react-router-dom'
 
 const AboutPage = lazy(() => import('@/pages/about-page'))
 const HomePage = lazy(() => import('@/pages/home-page'))

--- a/src/routes/private-route.tsx
+++ b/src/routes/private-route.tsx
@@ -1,5 +1,6 @@
-import { useAuthStore } from '@/store/auth-store'
 import { Navigate, Outlet } from 'react-router-dom'
+
+import { useAuthStore } from '@/store/auth-store'
 
 export default function PrivateRoutes(): JSX.Element {
   const token = useAuthStore.use.token()

--- a/src/store/auth-store.ts
+++ b/src/store/auth-store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 
-import { User } from '@/types/user'
 import { createSelectors } from '@/store/create-selector'
+import { User } from '@/types/user'
 
 type AuthState = {
   token: string | null


### PR DESCRIPTION
this PR introduces [@ianvs/prettier-plugin-sort-imports](https://github.com/IanVS/prettier-plugin-sort-imports) (improved [@trivago/prettier-plugin-sort-imports](https://github.com/trivago/prettier-plugin-sort-imports)) to ensure consistent import order across project. The following import order is applied:

```json
  "importOrder": ["^react", "<THIRD_PARTY_MODULES>", "", "^@/(.*)$", "^[./]"]
```

example of new import order:

```ts
import { useNavigate } from 'react-router-dom'
import { User2 } from 'lucide-react'

import { Button } from '@/components/ui/button'
import {
  DropdownMenu,
  DropdownMenuContent,
  DropdownMenuGroup,
  DropdownMenuItem,
  DropdownMenuLabel,
  DropdownMenuSeparator,
  DropdownMenuTrigger
} from '@/components/ui/dropdown-menu'
import { useAuthStore } from '@/store/auth-store'
import { User } from '@/types/user'
```

- [x] run build on local and passed
- [ ] build does not exceed 500kb
